### PR TITLE
Change column action/filter to use slug

### DIFF
--- a/src/CPT.php
+++ b/src/CPT.php
@@ -181,10 +181,10 @@ class CPT {
         $this->add_action( 'init', array( &$this, 'register_exisiting_taxonomies' ) );
 
         // Add taxonomy to admin edit columns.
-        $this->add_filter( 'manage_edit-' . $this->post_type_name . '_columns', array( &$this, 'add_admin_columns' ) );
+        $this->add_filter( 'manage_edit-' . $this->slug . '_columns', array( &$this, 'add_admin_columns' ) );
 
         // Populate the taxonomy columns with the posts terms.
-        $this->add_action( 'manage_' . $this->post_type_name . '_posts_custom_column', array( &$this, 'populate_admin_columns' ), 10, 2 );
+        $this->add_action( 'manage_' . $this->slug . '_posts_custom_column', array( &$this, 'populate_admin_columns' ), 10, 2 );
 
         // Add filter select option to admin edit.
         $this->add_action( 'restrict_manage_posts', array( &$this, 'add_taxonomy_filters' ) );


### PR DESCRIPTION
In my opinion it's better for WordPress to load the filter via the slug of the custom post type. This is a protection just in case a person uses a different post_type_name vs the slug for UI purposes. For example: 

```php
$gallery = new CPT(array(
    'post_type_name' => 'gallery',
    'singular' => 'Gallery',
    'plural' => 'Galleries',
    'slug' => 'galleries'
));
```
will not work without the "manage_edit-..." filter using the post_type_name.

Shoutout to @tjwallis for the suggestion